### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ projectName = xphoot
 appName = com.enonic.app.xphoot
 xpVersion = 8.0.0-B4
 
-version=2.1.4-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
Bumps master to the next major version line for XP 8 and configures CI to recognize both `master` and the new `2.x` maintenance branch as release branches.

## Changes

- `gradle.properties`: `version=2.1.4-SNAPSHOT` → `version=3.0.0-SNAPSHOT`
- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` block listing `master` and `2.x`

## Companion

The `2.x` maintenance branch was created at SHA `75d02799183cb07edb27243bce2cdcfea616b8d3` (the post-`v2.1.3` "next SNAPSHOT" commit, `version=2.1.4-SNAPSHOT`). A companion PR against `2.x` adds the matching `releaseBranch:` workflow config so pushes there are picked up as release-branch builds.

Reference: app-booster's master/1.x split.