### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `releaseBranch:` block to the workflow on the new `2.x` maintenance branch so pushes here are recognized as release-branch builds (the action reads `releaseBranch:` from the branch's own workflow file).

## Changes

- `.github/workflows/enonic-gradle.yml`: add `releaseBranch:` block listing `master` and `2.x`. Existing keys (including `repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}`) are preserved.

## Companion

Companion PR against `master` (#57) bumps `master` to `3.0.0-SNAPSHOT` and applies the same `releaseBranch:` config there. The `2.x` branch was created at SHA `75d02799183cb07edb27243bce2cdcfea616b8d3` (post-`v2.1.3` "next SNAPSHOT" commit; `version=2.1.4-SNAPSHOT`).

Reference: app-booster's master/1.x split.