### PR TITLE
Fix XP 8 boot: branch context + lib bumps #60

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-cache = "2.2.1"
-httpClient = "3.2.2"
+cache = "3.0.0-SNAPSHOT"
+httpClient = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -17,7 +17,8 @@ function runInContext(callback) {
     try {
         result = contextLib.run({
             principals: ["role:system.admin"],
-            repository: 'com.enonic.cms.' + projectData.id
+            repository: 'com.enonic.cms.' + projectData.id,
+            branch: 'draft'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);


### PR DESCRIPTION
Closes #60.

## What changed

- `main.js` `runInContext()`: add `branch: 'draft'` to the `contextLib.run` params. XP 8 requires a branch on the context, and without it the first-boot sample-quiz import dies with `Error: branch is required` and the bundled demo content (4 sample quizzes + their images/audio) never gets imported.
- `gradle/libs.versions.toml`: bump `lib-cache` 2.2.1 → 3.0.0-SNAPSHOT and `lib-http-client` 3.2.2 → 4.0.0-SNAPSHOT (their XP 8 SNAPSHOT lines on `repo.enonic.com/dev`).

## Why

E2E verification against XP 8.0.0-B4 (the version declared in `gradle.properties`) showed two issues:

1. App bundle reached ACTIVE on a clean XP 8 install, but `main.js` logged `(/main.js) Error: branch is required` right after `Project "xphoot" successfully created`, meaning no demo quizzes ever made it into the repo on a fresh install.
2. The previous `lib-cache` / `lib-http-client` versions are the XP 7 lines; the SNAPSHOTs above are the matching XP 8 lines.

## Verified

After this patch, on a fresh XP 8.0.0-B4 install with the rebuilt jar dropped into `home/deploy/`:

- `Started application com.enonic.app.xphoot bundle 117` in `server.log`.
- `Project "xphoot" successfully created` followed by the full `Imported nodes` / `Imported binaries` listing (4 sample quizzes + the depeche-mode, nerd-quiz screenshots, geo-quiz mp3, etc.) — no `Error: branch is required`.
- `/site/xphoot/draft/xphoot` → HTTP 200 (`<title>XpHoot</title>`).
- `/site/xphoot/draft/xphoot/master` → HTTP 200 (master view HTML).
- `/site/xphoot/draft/xphoot/player` → HTTP 200 (player view HTML).
- `/_/asset/com.enonic.app.xphoot/...` → HTTP 200.
- No app-attributable `ERROR` / `Exception` in `server.log` after startup.