### PR TITLE
Migrate to lib-asset #62

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     include libs.lib.thymeleaf
     include libs.lib.cache
     include libs.lib.httpClient
+    include libs.lib.asset
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,10 @@
 thymeleaf = "3.0.0-SNAPSHOT"
 cache = "3.0.0-SNAPSHOT"
 httpClient = "4.0.0-SNAPSHOT"
+asset = "2.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
 lib-cache = { module = "com.enonic.lib:lib-cache", version.ref = "cache" }
 lib-httpClient = { module = "com.enonic.lib:lib-http-client", version.ref = "httpClient" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -6,3 +6,5 @@ mappings:
   - controller: "/cms/controllers/player/player.js"
     order: 50
     pattern: "/player"
+apis:
+  - "asset"

--- a/src/main/resources/services/spotify/spotify.js
+++ b/src/main/resources/services/spotify/spotify.js
@@ -1,4 +1,5 @@
 var portalLib = require('/lib/xp/portal');
+var assetLib = require('/lib/enonic/asset');
 var httpClient = require('/lib/http-client');
 var cacheLib = require('/lib/cache');
 
@@ -288,5 +289,5 @@ function parseTrack(spotifyTrack) {
 }
 
 function defaultIcon() {
-    return portalLib.assetUrl({path: 'img/Spotify_logo_without_text.svg'});
+    return assetLib.assetUrl({path: 'img/Spotify_logo_without_text.svg'});
 }


### PR DESCRIPTION
Closes #62

`portal.assetUrl` is `@deprecated` in lib-portal (*"Use libAsset or libStatic instead. This function will be removed in future versions."*). This PR migrates the single call site in this app to **lib-asset**.

## Changes

- `build.gradle` + `gradle/libs.versions.toml`: add `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT` (current XP 8 line).
- `src/main/resources/cms/site.yaml`: register the asset API (`apis: ["asset"]`) so the URL is mounted on the Site descriptor.
- `src/main/resources/services/spotify/spotify.js`: swap `portalLib.assetUrl({path:...})` → `assetLib.assetUrl({path:...})` in `defaultIcon()`. `portalLib` is kept because `getSiteConfig()` still uses it.

lib-asset is the right target here: the single call site is a Site service, and lib-asset is documented to cover Site / WebApp / AdminTool descriptors.

## Test plan

- [x] `./gradlew build --refresh-dependencies` clean.
- [x] E2E in `claude-dev`: deployed jar into a `/tmp/xp-e2e-*` runtime, bootstrapped a Site `/site/default/master/e2e` with this app applied, hit `/_/service/com.enonic.app.xphoot/spotify?ids=["test1"]` — service returns HTTP 200 with `iconUrl` = `/site/default/master/e2e/_/com.enonic.app.xphoot:asset/<fingerprint>/img/Spotify_logo_without_text.svg`.
- [x] The generated asset URL returns HTTP 200, `Content-Type: image/svg+xml`, 1046 bytes — the Spotify logo SVG.