### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -7,9 +7,7 @@ const projectData = {
     id: 'xphoot',
     displayName: 'xpHoot',
     description: 'The xpHoot site',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 function runInContext(callback) {


### PR DESCRIPTION
## Summary

Replace the nested `readAccess: { public: true }` shape with the flat `publicRead: true` boolean introduced by enonic/xp#12043.

`main.js` creates the `xphoot` project on first boot. Under XP 8 master the old shape fails at runtime; there is no back-compat shim.

## Reference

- Source PR: enonic/xp#12043
- Upgrade notes: [doc-code `docs/upgrade.adoc`](https://github.com/enonic/doc-code/blob/master/docs/upgrade.adoc) (lib-project section)
- API docs: [doc-code `docs/libraries/lib-project.adoc`](https://github.com/enonic/doc-code/blob/master/docs/libraries/lib-project.adoc)

## Test plan

- [x] `./gradlew build` is green locally
- [ ] CI build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)