### PR TITLE
Import fix: content.import attr, vacuum skip

### DIFF
--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,33 +1,14 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="applicationId"/>
-    <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
-    <xsl:variable name="placeholderApp" select="'com.enonic.app.xphoot'"/>
-    <xsl:variable name="placeholderAppDashed" select="translate($placeholderApp, '.', '-')"/>
+    <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="string[starts-with(text(),concat($placeholderApp,':'))]">
-        <string>
-            <xsl:attribute name="name">
-                <xsl:value-of select="@name"/>
-            </xsl:attribute>
-            <xsl:value-of select="concat($applicationId, substring-after(.,$placeholderApp))"/>
-        </string>
-    </xsl:template>
-
-    <xsl:template match="string[text() = $placeholderApp]">
-        <string>
-            <xsl:attribute name="name">
-                <xsl:value-of select="@name"/>
-            </xsl:attribute>
-            <xsl:value-of select="$applicationId"/>
-        </string>
-    </xsl:template>
-
-    <xsl:template match="property-set/@name[. = $placeholderAppDashed]">
-        <xsl:attribute name="name">
-            <xsl:value-of select="$applicationIdDashed"/>
-        </xsl:attribute>
+    <xsl:template match="data/property-set[@name='publish']">
+        <xsl:if test="$keepPublishFirst != 'false'">
+            <xsl:copy>
+                <xsl:apply-templates select="@*|*[@name='first']"/>
+            </xsl:copy>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="@*|node()">
@@ -35,6 +16,4 @@
             <xsl:apply-templates select="@*|node()"/>
         </xsl:copy>
     </xsl:template>
-
-
 </xsl:stylesheet>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -61,6 +61,13 @@ function createContent() {
         xsltParams: {
             applicationId: app.name
         },
+        versionAttributes: {
+            'content.import': {
+                user: "role:system.admin",
+                optime: new Date().toISOString()
+            },
+            'vacuum.skip': {}
+        },
         includeNodeIds: true
     });
     log.info('-------------------');


### PR DESCRIPTION
## Summary

Apply the canonical import-bootstrap fix from [enonic/app-features#248](https://github.com/enonic/app-features/pull/248) (same fix landed in [app-superhero-blog@dd30922](https://github.com/enonic/app-superhero-blog/commit/dd30922)):

- **`replace_app.xsl`** — drop the placeholder-app rewriting templates. They were no-ops here because `placeholderApp` equals `app.name`. Keep only the publish-fields cleanup (`keepPublishFirst`).
- **`main.js`** — add `versionAttributes` to the `exportLib.importNodes(...)` call so imported content is marked with `content.import` and `vacuum.skip`. Without these, vacuum can reclaim bootstrap-imported content, and downstream consumers can't tell the content was bootstrap-imported.

`xsltParams: { applicationId: app.name }` left in place (XSLT silently ignores the unused param) to keep the diff conservative — matches what both reference fixes did.

## Test plan

- [x] `./gradlew build` clean
- [ ] (optional) Boot fresh XP install, confirm sample content imports and that `content.import` / `vacuum.skip` version attributes are present on a sample imported node