### PR TITLE
Modernize demo importer #66

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     include xplibs.project
     include xplibs.export
     include xplibs.portal
+    include xplibs.task
     include xplibs.websocket
     include libs.lib.thymeleaf
     include libs.lib.cache

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = com.enonic.app
 projectName = xphoot
 appName = com.enonic.app.xphoot
-xpVersion = 8.0.0-B4
+xpVersion = 8.0.0-RC1
 
 version=3.0.0-SNAPSHOT

--- a/src/main/resources/import/_/node.xml
+++ b/src/main/resources/import/_/node.xml
@@ -1,16 +1,9 @@
 <node>
-    <id>7a2c4de2-bf29-4e29-9d26-ef43543954f6</id>
+    <id>d2b74b62-7d6d-4333-9489-90b858a51ee6</id>
     <childOrder>displayname ASC</childOrder>
     <nodeType>default</nodeType>
-    <timestamp>2019-04-05T15:11:44.841Z</timestamp>
-    <inheritPermissions>false</inheritPermissions>
+    <timestamp>2026-05-29T12:22:12.310Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -35,6 +28,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <string name="type">base:folder</string>
@@ -53,6 +91,10 @@
             <includeInAllText>false</includeInAllText>
         </defaultConfig>
         <pathIndexConfigs/>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,19 +1,54 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="keepPublishFirst" select="'true'"/>
+  <xsl:output method="xml" indent="yes"/>
 
-    <xsl:template match="data/property-set[@name='publish']">
-        <xsl:if test="$keepPublishFirst != 'false'">
-            <xsl:copy>
-                <xsl:apply-templates select="@*|*[@name='first']"/>
-            </xsl:copy>
-        </xsl:if>
-    </xsl:template>
+  <xsl:param name="applicationId"/>
+  <xsl:param name="projectName"/>
+  <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="@*|node()">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    </xsl:template>
+  <!-- Values the bundled /import data was exported with -->
+  <xsl:variable name="applicationIdPlaceholder" select="'com.enonic.app.xphoot'"/>
+  <xsl:variable name="projectNamePlaceholder" select="'xphoot'"/>
+
+  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
+  <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>
+
+  <!-- app key inside descriptor-style string values: "<app>:descriptor" -->
+  <xsl:template match="string[starts-with(text(), concat($applicationIdPlaceholder, ':'))]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="concat($applicationId, substring-after(., $applicationIdPlaceholder))"/>
+    </string>
+  </xsl:template>
+
+  <!-- bare app key string value -->
+  <xsl:template match="string[text() = $applicationIdPlaceholder]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="$applicationId"/>
+    </string>
+  </xsl:template>
+
+  <!-- dashed app key in property-set names (x.<dashed-app>...) -->
+  <xsl:template match="property-set/@name[. = $applicationIdPlaceholderDashed]">
+    <xsl:attribute name="name"><xsl:value-of select="$applicationIdDashed"/></xsl:attribute>
+  </xsl:template>
+
+  <!-- project-role principals: role:cms.project.<placeholder>.<suffix> -->
+  <xsl:template match="principal/@key[starts-with(., concat('role:cms.project.', $projectNamePlaceholder, '.'))]">
+    <xsl:attribute name="key">
+      <xsl:value-of select="concat('role:cms.project.', $projectName, '.', substring-after(., concat('role:cms.project.', $projectNamePlaceholder, '.')))"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy><xsl:apply-templates select="@*|node()"/></xsl:copy>
+  </xsl:template>
+
+  <!-- Remove publishing metadata on import -->
+  <xsl:template match="data/property-set[@name='publish']">
+    <xsl:if test="$keepPublishFirst != 'false'">
+      <xsl:copy><xsl:apply-templates select="@*|*[@name='first']"/></xsl:copy>
+    </xsl:if>
+  </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/import/xphoot/_/node.xml
+++ b/src/main/resources/import/xphoot/_/node.xml
@@ -2,15 +2,8 @@
     <id>70bed510-28c6-4e8b-82c3-48374c329ad2</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.571Z</timestamp>
-    <inheritPermissions>false</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.866Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -41,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -62,7 +100,6 @@
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
         <property-set name="components">
             <string name="type">page</string>
@@ -105,7 +142,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -258,7 +295,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -288,7 +325,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -311,6 +348,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/_templates/_/node.xml
+++ b/src/main/resources/import/xphoot/_templates/_/node.xml
@@ -2,15 +2,8 @@
     <id>1e4eeb3b-0154-4978-a31f-e37b6e84ddf2</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.470Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.889Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -133,7 +171,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -163,7 +201,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -176,6 +214,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/results/_/node.xml
+++ b/src/main/resources/import/xphoot/results/_/node.xml
@@ -2,15 +2,8 @@
     <id>092e7670-a9d1-46cb-a245-63b04b4fb706</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.579Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.919Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -41,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -54,7 +92,6 @@
         <property-set name="data"/>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -137,7 +174,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -167,7 +204,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -180,6 +217,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/80s-music/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/80s-music/_/node.xml
@@ -2,15 +2,8 @@
     <id>b6e8f325-d143-4941-8880-4a6123cca859</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.452Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.949Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -110,7 +148,6 @@
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -193,7 +230,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -223,7 +260,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -236,6 +273,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/80s-music/depeche-mode.jpg/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/80s-music/depeche-mode.jpg/_/node.xml
@@ -2,15 +2,8 @@
     <id>8d540206-fe5d-435c-a263-9c7347d36b8b</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.464Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.997Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">depeche-mode.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">35639</long>
+            <string name="sha512">47bc7d75386426840238f7538625827eb5066f94b767f992db1b00cd9655a4f843698130c3262351c5ffd1ea547013aafa9574b1f6722de33cd4b6da28a32e1f</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/_/node.xml
@@ -2,15 +2,8 @@
     <id>ed37ffe3-5c6e-4f96-8d7b-97cc016eb000</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.441Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.930Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -41,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -54,7 +92,6 @@
         <property-set name="data"/>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -137,7 +174,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -167,7 +204,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -180,6 +217,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/funfact-quiz/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/funfact-quiz/_/node.xml
@@ -2,15 +2,8 @@
     <id>8bf23e69-932e-4cc3-8d61-e97df2a295fa</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.475Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.963Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -87,7 +125,6 @@
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -170,7 +207,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -200,7 +237,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -213,6 +250,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/geo-quiz/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/geo-quiz/_/node.xml
@@ -2,15 +2,8 @@
     <id>3eb70a75-dd78-4f39-9d42-48efa4969ab2</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.485Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.971Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -89,7 +127,6 @@
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -172,7 +209,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -202,7 +239,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -215,6 +252,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/geo-quiz/bensound-thelounge.mp3/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/geo-quiz/bensound-thelounge.mp3/_/node.xml
@@ -2,15 +2,8 @@
     <id>06d1da21-7ad2-4636-b2b6-90cee9221eda</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.494Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.012Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -41,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -66,10 +104,11 @@
             <binaryReference name="binary">bensound-thelounge.mp3</binaryReference>
             <string name="mimeType">audio/mp3</string>
             <long name="size">3585099</long>
+            <string name="sha512">e54c817e7b4f86e6d5d44dbbed631497cb6e3a8f7464d70696aab40a3ef58064d4e8577a13a70d40caaa468afc44dc2c85e4c6a83c444851445331874e51d13b</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -152,7 +191,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -182,7 +221,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -195,6 +234,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/Screen Shot 2016-04-22 at 11.10.56.png/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/Screen Shot 2016-04-22 at 11.10.56.png/_/node.xml
@@ -2,15 +2,8 @@
     <id>58932d30-e164-419c-a34e-8fa4f4cba96b</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.514Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.024Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">Screen Shot 2016-04-22 at 11.10.56.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">59559</long>
+            <string name="sha512">8b74f99c78a6de7f1392b7ba9530813f486ef8e2e08cab3e89140a832e54812903d95f397a6637a004e057f409d47cbb4ed348b91db9ea7ff067410bd884de74</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/Screen Shot 2016-04-22 at 12.15.43.png/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/Screen Shot 2016-04-22 at 12.15.43.png/_/node.xml
@@ -2,15 +2,8 @@
     <id>544719e8-54fb-4c29-83c8-1a72e0a59701</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.523Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.035Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">Screen Shot 2016-04-22 at 12.15.43.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">22700</long>
+            <string name="sha512">ff38eb6e4cb82faba7afff0431bcf42ec549b723be8d38183116ee4c7b6a2f5be7e444438469282506acf0f73309fb571b141094b68ee46abb8ab070c1d6805b</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/Screen Shot 2016-04-22 at 12.19.29.png/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/Screen Shot 2016-04-22 at 12.19.29.png/_/node.xml
@@ -2,15 +2,8 @@
     <id>907e707f-8d62-423f-b0f3-04095ebe8290</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.532Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.049Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">Screen Shot 2016-04-22 at 12.19.29.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">662076</long>
+            <string name="sha512">52c035fd3def8060af1a2e22db301554e793d8558e615237acba1f85155e270fb3d95b6108b36f7dbc5c19ef183c852df23ff6778bc37c7bc45ddd4fd3bdc8b3</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/_/node.xml
@@ -2,15 +2,8 @@
     <id>f91ef3df-e23f-4cad-a22b-911304334c49</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.503Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:13.980Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -117,7 +155,6 @@
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -200,7 +237,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -230,7 +267,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -243,6 +280,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/a500.jpg/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/a500.jpg/_/node.xml
@@ -2,15 +2,8 @@
     <id>149f85f3-ec87-4dea-9b4f-8a8e8cb3fcc5</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.542Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.061Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">a500.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">136402</long>
+            <string name="sha512">c3f786a25042558c1317e13031366d314c728d60c12af21db61b320dabf134bfc1a8def725cdbce795f8407bbfe99946c262a2e98734de1affe0777b6474a268</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/ghostngoblins_c64.png/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/ghostngoblins_c64.png/_/node.xml
@@ -2,15 +2,8 @@
     <id>8982d55c-b3b0-4ea0-8cb5-eb5bd0fb1eb8</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.551Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.073Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">ghostngoblins_c64.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">150378</long>
+            <string name="sha512">c1ef2e96b9da4844a0164f9bd546d1abf85ef6112c0199730f80448fc194fc90e8260040a585661ed3fa84f0002a67cfe96dfc02c804f8dbb17432574e5a5fdc</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/linus.png/_/node.xml
+++ b/src/main/resources/import/xphoot/sample-quizzes/nerd-quiz/linus.png/_/node.xml
@@ -2,15 +2,8 @@
     <id>ee7414cf-3169-481e-98e3-1ceae2668900</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-04-05T15:11:46.563Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T12:22:14.083Z</timestamp>
     <permissions>
-        <principal key="role:cms.cm.app">
-            <allow type="array">
-                <value>READ</value>
-            </allow>
-            <deny type="array"/>
-        </principal>
         <principal key="role:system.admin">
             <allow type="array">
                 <value>READ</value>
@@ -36,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.xphoot.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -81,10 +119,11 @@
             <binaryReference name="binary">linus.png</binaryReference>
             <string name="mimeType">image/png</string>
             <long name="size">218140</long>
+            <string name="sha512">66e21456a705f16eab8afc77be8fd9fe8599f0510e12337ed1bf6b8287d561b9cd2f1332d22305735ecb0df914ba852512648fb087e6d507157e90abafa52c04</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="first">2019-04-05T15:11:46.429Z</dateTime>
-            <dateTime name="from">2019-04-05T15:11:46.429Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -167,7 +206,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -197,7 +236,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -210,6 +249,10 @@
                 <path>attachment</path>
             </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -1,20 +1,27 @@
-const projectLib = require('/lib/xp/project');
 const contextLib = require('/lib/xp/context');
+const contentLib = require('/lib/xp/content');
 const clusterLib = require('/lib/xp/cluster');
 const exportLib = require('/lib/xp/export');
+const projectLib = require('/lib/xp/project');
+const taskLib = require('/lib/xp/task');
 
 const projectData = {
     id: 'xphoot',
     displayName: 'xpHoot',
     description: 'The xpHoot site',
-    publicRead: true
+    readAccess: {
+        public: true
+    }
 }
 
-function runInContext(callback) {
+const runInContext = function (callback) {
     let result;
     try {
         result = contextLib.run({
-            principals: ["role:system.admin"],
+            user: {
+                login: "su",
+                idProvider: "system"
+            },
             repository: 'com.enonic.cms.' + projectData.id,
             branch: 'draft'
         }, callback);
@@ -25,33 +32,44 @@ function runInContext(callback) {
     return result;
 }
 
-function createProject() {
+const createProject = function () {
     return projectLib.create(projectData);
 }
 
-function getProject() {
+const getProject = function () {
     return projectLib.get({
         id: projectData.id
     });
 }
 
-function initializeProject() {
-    let project = runInContext(getProject);
+const initialize = function () {
+    runInContext(() => {
+        const project = getProject();
+        if (!project) {
+            taskLib.executeFunction({
+                description: 'Importing content',
+                func: initProject
+            });
+        }
+        else {
+            log.debug(`Project ${project.id} exists, skipping import`);
+        }
+    });
+};
 
-    if (!project) {
-        log.info('Project "' + projectData.id + '" not found. Creating...');
-        project = runInContext(createProject);
+const initProject = function () {
+    runInContext(() => {
+        const project = createProject();
 
         if (project) {
             log.info('Project "' + projectData.id + '" successfully created');
-
-            log.info('Importing "' + projectData.id + '" data');
-            runInContext(createContent);
+            createContent();
+            publishRoot();
         } else {
-            log.error('Project "' + projectData.id + '" failed to be created');
+            log.error('Project "' + projectData.id + '" creation failed');
         }
-    }
-}
+    });
+};
 
 function createContent() {
     let importNodes = exportLib.importNodes({
@@ -59,34 +77,40 @@ function createContent() {
         targetNodePath: '/content',
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
-            applicationId: app.name
+            applicationId: app.name,
+            projectName: projectData.id
         },
         versionAttributes: {
             'content.import': {
-                user: "role:system.admin",
+                user: contextLib.get().authInfo.user.key,
                 optime: new Date().toISOString()
             },
             'vacuum.skip': {}
         },
         includeNodeIds: true
     });
-    log.info('-------------------');
-    log.info('Imported nodes:');
-    importNodes.addedNodes.forEach(element => log.info(element));
-    log.info('-------------------');
-    log.info('Updated nodes:');
-    importNodes.updatedNodes.forEach(element => log.info(element));
-    log.info('-------------------');
-    log.info('Imported binaries:');
-    importNodes.importedBinaries.forEach(element => log.info(element));
-    log.info('-------------------');
-    if (importNodes.importErrors.length !== 0) {
+    if (importNodes.importErrors.length > 0) {
         log.warning('Errors:');
         importNodes.importErrors.forEach(element => log.warning(element.message));
         log.info('-------------------');
     }
 }
 
-if (clusterLib.isMaster()) {
-    initializeProject();
+function publishRoot() {
+    const result = contentLib.publish({
+        keys: ['/xphoot'],
+        sourceBranch: 'draft',
+        targetBranch: 'master',
+        includeChildren: true,
+        includeDependencies: true,
+    });
+    if (!result || (result.failedContents && result.failedContents.length > 0)) {
+        log.warning('Could not publish imported content. failed=' + JSON.stringify(result && result.failedContents));
+    } else {
+        log.info('Published ' + (result.pushedContents ? result.pushedContents.length : 0) + ' content items.');
+    }
+}
+
+if (clusterLib.isLeader()) {
+    initialize();
 }


### PR DESCRIPTION
Closes #66.

## Summary

Brings the bundled demo importer up to the same standard as the merged
[`app-superhero-blog#174`](https://github.com/enonic/app-superhero-blog/pull/174),
[`app-hmdb#80`](https://github.com/enonic/app-hmdb/pull/80) and
[`app-image-xpert#54`](https://github.com/enonic/app-image-xpert/pull/54).

### `src/main/resources/import/replace_app.xsl`

Now fully parameter-driven. Takes:

- `applicationId` + `projectName` (live values, passed from `main.js`)
- `keepPublishFirst` (default `'true'`)

Placeholder values that the bundled `/import` data was exported with
(`com.enonic.app.xphoot` / `xphoot`) live as `<xsl:variable>` inside the
stylesheet, so callers don't need to know them. Templates rewrite:

- `string` starting with `<placeholder>:` -> app prefix swapped to `$applicationId`
- bare `<placeholder>` string value -> `$applicationId`
- `property-set/@name` matching the dashed app placeholder -> dashed `$applicationId`
- `principal/@key` starting with `role:cms.project.<placeholder>.` -> project segment swapped to `$projectName`
- `data/property-set[@name='publish']` stripped (kept only `first`)

Forks that rename either the app key or the project id now get correct
descriptor refs and `role:cms.project.<new-id>.*` principals on imported
content.

### `src/main/resources/main.js`

Modernized to match the merged superhero/hmdb/image-xpert pattern:

- `projectData.readAccess.public = true` (replaces `publicRead: true`)
- `runInContext` uses `user: { login: 'su', idProvider: 'system' }` (drops `principals: ['role:system.admin']`)
- `xsltParams` passes only the live targets (`applicationId: app.name`, `projectName: projectData.id`)
- `versionAttributes['content.import'].user` is `contextLib.get().authInfo.user.key` instead of the hardcoded role
- `publishRoot()` added — calls `contentLib.publish` with `includeChildren: true`, `includeDependencies: true`, inspects `failedContents`, logs `pushedContents.length`
- guard switched to `clusterLib.isLeader()`
- `taskLib.executeFunction({ description, func })` wraps the import

### Re-exported `/import` data

The 17 bundled `node.xml` files now carry the five canonical project-role
principals (`role:cms.project.xphoot.{owner,editor,author,contributor,viewer}`)
alongside `role:system.admin` / `role:cms.admin` / `role:system.everyone`,
applied via `contentLib.applyPermissions(scope: 'TREE')` in a one-off
bootstrap, then exported via `exportLib.exportNodes` and copied back.

All 8 media nodes get `<string name="sha512">HASH</string>` +
`<string name="text"/>` injected after `<long name="size">…</long>` in
their `attachment` property-set, where `HASH` is `sha512sum` of the
corresponding `_/bin/<file>` binary (matching what XP would compute on
ingest).

### Other

- `gradle.properties`: `xpVersion` bumped `8.0.0-B4` -> `8.0.0-RC1`. The
  B4-bundled `lib-project` `CreateProjectHandler` calls
  `CreateProjectParams.Builder.permissions(AccessControlList)` which is
  no longer on the platform builder (replaced by `publicRead(boolean)` /
  `readAccess`), so `projectLib.create(...)` failed with
  `NoSuchMethodError` until the bump.
- `build.gradle`: added `include xplibs.task` (for `taskLib.executeFunction`).

## Test plan

E2E inside `claude-dev` against `xp-distro` 8.0.0-SNAPSHOT:

- [x] `./gradlew build` green
- [x] Fresh xp-distro install, jar deployed, server.log shows:
  - `Started application com.enonic.app.xphoot`
  - `Project "xphoot" successfully created`
  - `Published 16 content items.`
  - no import errors / warnings
- [x] All 17 `node.xml` carry `role:cms.project.xphoot.*` principals
- [x] Every media `node.xml` has a `<string name="sha512">` matching
  `sha512sum` of the linked `_/bin/<file>` (8 / 8)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>