### PR TITLE
GraalJS Compatibility #72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -34,14 +33,6 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,30 @@ dependencies {
     include libs.lib.cache
     include libs.lib.httpClient
     include libs.lib.asset
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.1'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
     mavenCentral()
     xp.enonicRepo( 'dev' )
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = com.enonic.app
 projectName = xphoot
 appName = com.enonic.app.xphoot
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 
 version=3.0.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -3,7 +3,6 @@ const contentLib = require('/lib/xp/content');
 const clusterLib = require('/lib/xp/cluster');
 const exportLib = require('/lib/xp/export');
 const projectLib = require('/lib/xp/project');
-const taskLib = require('/lib/xp/task');
 
 const projectData = {
     id: 'xphoot',
@@ -44,15 +43,8 @@ const getProject = function () {
 
 const initialize = function () {
     runInContext(() => {
-        const project = getProject();
-        if (!project) {
-            taskLib.executeFunction({
-                description: 'Importing content',
-                func: initProject
-            });
-        }
-        else {
-            log.debug(`Project ${project.id} exists, skipping import`);
+        if (!getProject()) {
+            initProject();
         }
     });
 };

--- a/src/test/java/com/enonic/app/xphoot/MainScriptTest.java
+++ b/src/test/java/com/enonic/app/xphoot/MainScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.xphoot;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class MainScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/test/main-test.js";
+    }
+}

--- a/src/test/resources/test/main-test.js
+++ b/src/test/resources/test/main-test.js
@@ -1,0 +1,73 @@
+var t = require('/lib/xp/testing');
+
+var calls = {
+    projectGet: 0,
+    projectCreate: 0,
+    importNodes: 0,
+    publish: 0,
+    createdId: null
+};
+
+t.mock('/lib/xp/cluster.js', {
+    isLeader: function () {
+        return true;
+    }
+});
+
+t.mock('/lib/xp/context.js', {
+    run: function (params, callback) {
+        return callback();
+    },
+    get: function () {
+        return {
+            authInfo: {
+                user: {
+                    key: 'user:system:su'
+                }
+            }
+        };
+    }
+});
+
+t.mock('/lib/xp/project.js', {
+    get: function () {
+        calls.projectGet++;
+        return null;
+    },
+    create: function (params) {
+        calls.projectCreate++;
+        calls.createdId = params.id;
+        return {
+            id: params.id
+        };
+    }
+});
+
+t.mock('/lib/xp/export.js', {
+    importNodes: function () {
+        calls.importNodes++;
+        return {
+            importErrors: []
+        };
+    }
+});
+
+t.mock('/lib/xp/content.js', {
+    publish: function () {
+        calls.publish++;
+        return {
+            failedContents: [],
+            pushedContents: ['/xphoot']
+        };
+    }
+});
+
+require('/main.js');
+
+exports.testInitImportsContentWhenProjectMissing = function () {
+    t.assertEquals(1, calls.projectGet, 'getProject should be called once');
+    t.assertEquals(1, calls.projectCreate, 'createProject should be called once');
+    t.assertEquals('xphoot', calls.createdId, 'created project id');
+    t.assertEquals(1, calls.importNodes, 'content should be imported synchronously');
+    t.assertEquals(1, calls.publish, 'root content should be published synchronously');
+};


### PR DESCRIPTION
Fixes #72

## What

`task.executeFunction` promises to run a closure on another thread, which GraalJS cannot honor — a function is bound to the context that created it. It is deprecated and **fails fast on GraalJS**, so this app could not initialize at all on that engine.

Here it was only offloading *initialization*, and that offload no longer has a purpose: enonic/xp#12198 holds every top-level execution until `main.js` has finished (fixes enonic/xp#7821), so the rest of the app already sees an initialized app. `initProject` is now called directly:

```js
if (!getProject()) {
    initProject();
}
```

No named task, no `executeFunction`. The `description` is lost, which only affected the task list. The now-unused `/lib/xp/task` require is removed.

## Tested on both engines

The JS test runs once per script engine — Nashorn via `test` (the platform default) and GraalJS via `testGraalJs` — both wired into `check`:

```
test         1 test, 0 failed
testGraalJs  1 test, 0 failed
```

`MainScriptTest` (`ScriptRunnerSupport`) loads `/main.js` with the `/lib/xp/*` modules mocked and asserts that init runs synchronously — `projectLib.create`, `exportLib.importNodes` and `contentLib.publish` are each called once when the project is missing. Before the fix that path went through `task.executeFunction`, which fails fast on GraalJS.

## Note on `xpVersion` — CI stays red for now

The bump to `8.1.0-SNAPSHOT` (and `enonicRepo('dev')`, already in place) is required by `testGraalJs`, not by the fix — the fix alone is green on Nashorn.

`MainScriptTest` extends `ScriptRunnerSupport`, whose test discovery closed the script executor before the dynamic tests ran; on GraalJS every test then failed with `IllegalStateException: The Context is already closed`. That is fixed in enonic/xp#12198 ("Keep the script executor alive through JS test discovery"), so:

- verified green above against a local build of that branch (`publishToMavenLocal`);
- **CI `testGraalJs` will stay red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`.

Holding this as a **draft** until then. Reference: enonic/lib-sql#154.
